### PR TITLE
Readme: Avoid having to manually rename wget outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ For legal reasons all ROMs are kept outside the FPGA bitstream distributed
 here. The Commodore ROMs (three for the C64 and two for the 1541) can be
 fetched with
 ```
-wget http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/c64/basic.901226-01.bin
-wget http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/c64/characters.901225-01.bin
-wget http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/c64/kernal.901227-03.bin
-wget http://www.zimmers.net/anonftp/pub/cbm/firmware/drives/new/1541/1540-c000.325302-01.bin
-wget http://www.zimmers.net/anonftp/pub/cbm/firmware/drives/new/1541/1541-e000.901229-01.bin
+wget -O basic.bin http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/c64/basic.901226-01.bin
+wget -O characters.bin http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/c64/characters.901225-01.bin
+wget -O kernal.bin http://www.zimmers.net/anonftp/pub/cbm/firmware/computers/c64/kernal.901227-03.bin
+wget -O 1540-c000.bin http://www.zimmers.net/anonftp/pub/cbm/firmware/drives/new/1541/1540-c000.325302-01.bin
+wget -O 1541-e000.bin http://www.zimmers.net/anonftp/pub/cbm/firmware/drives/new/1541/1541-e000.901229-01.bin
 ```
 they then need to be placed in `/media/Assets/c64/common/` as follows
 ```


### PR DESCRIPTION
Tweaks the wget commands in the readme so the ROM filenames end up already being correct without having to manually rename them afterwards. 

I read this part of the readme too quickly and then was confused why the core wouldn't load for me.